### PR TITLE
fix: add mouseleave event to outsideActions

### DIFF
--- a/src/IG/interactor/interactor.js
+++ b/src/IG/interactor/interactor.js
@@ -191,7 +191,7 @@ Interactor.register("Interactor", {});
 Interactor.register("TrajectoryInteractor", {
   startActions: "mousedown",
   runningActions: "mousemove",
-  outsideActions: "mouseup",
+  outsideActions: ["mouseup", "mouseleave"],
   backInsideActions: "mousedown",
 });
 


### PR DESCRIPTION
When you moving a pointer too fast, it may outside the target.